### PR TITLE
#24: Setup environment dependent logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 dist-ssr
 *.local
+logs

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -15,8 +15,10 @@ module.exports = {
     '@typescript-eslint',
   ],
   rules: {
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-shadow': ['error'],
     'import/no-unresolved': 'off', // handled by typescript
     'import/extensions': 'off',
-    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    'no-shadow': 'off',
   },
 };

--- a/server/src/utils/log.ts
+++ b/server/src/utils/log.ts
@@ -1,0 +1,49 @@
+/* eslint-disable no-console */
+import fs from 'fs';
+import { NodeEnv } from '../config/environment';
+
+type LogType = 'anomaly' | 'error' | 'info';
+
+interface Log {
+    event: string;
+    user?: string;
+    [info: string]: any;
+}
+
+let logFile: fs.WriteStream;
+let errorFile: fs.WriteStream;
+let anomalyFile: fs.WriteStream;
+
+const writeToConsole = (logLine: string, type: LogType) => {
+  if (type === 'info') console.log(logLine);
+  else if (type === 'error') console.error(logLine);
+  else console.warn(logLine);
+};
+
+const writeToFile = (logLine: string, type: LogType) => {
+  if (type === 'info') logFile.write(`${logLine}\n`);
+  else if (type === 'error') errorFile.write(`${logLine}\n`);
+  else anomalyFile.write(`${logLine}\n`);
+};
+
+export const openLogFiles = async () => {
+  if (!fs.existsSync('logs/')) {
+    await fs.promises.mkdir('logs/');
+  }
+
+  logFile = fs.createWriteStream('logs/info.log', { flags: 'a' });
+  errorFile = fs.createWriteStream('logs/error.log', { flags: 'a' });
+  anomalyFile = fs.createWriteStream('logs/anomaly.log', { flags: 'a' });
+};
+
+export const writeLog = (log: Log, logType: LogType) => {
+  const timestamp = new Date().toLocaleString('en-GB', { timeZone: 'UTC' });
+  const logInfo = Object.entries(log).map(([key, value]) => `${key}: ${value}`).join(', ');
+  const logString = `${timestamp} - ${logInfo}`;
+
+  if (process.env.NODE_ENV as NodeEnv === 'production') {
+    writeToFile(logString, logType);
+  } else {
+    writeToConsole(logString, logType);
+  }
+};


### PR DESCRIPTION
## Summary of Changes
* Ignored the `no-shadow` eslint rule because it's giving false positives due to a clash with Typescript.
* Created a logging helper which will write logs to the console in development and will write them to files for production.
* Moved main loop code into a `main()` method. I did this because node doesn't have top-level async-await and we need this for opening the log files.
* If the log files don't exist yet, they will be created when you run `yarn prod` or `yarn prod:server`

### Example logs
```
27/01/2022, 14:31:08 - event: server started on port 8080, user: server
27/01/2022, 14:31:17 - event: user connected to websocket, user: 5b01d595-5022-4c42-9250-9bb88fc60cdd
27/01/2022, 14:31:24 - event: user connected to websocket, user: 97d6eeeb-2c4c-456e-a7c2-f55a1cfe384c
27/01/2022, 14:31:28 - event: user sent message, user: 97d6eeeb-2c4c-456e-a7c2-f55a1cfe384c, message: hey
27/01/2022, 14:31:35 - event: user sent message, user: 5b01d595-5022-4c42-9250-9bb88fc60cdd, message: get out of my face
27/01/2022, 14:31:39 - event: user sent message, user: 97d6eeeb-2c4c-456e-a7c2-f55a1cfe384c, message: oh
27/01/2022, 14:31:41 - event: websocket closed, user: 97d6eeeb-2c4c-456e-a7c2-f55a1cfe384c
27/01/2022, 14:31:42 - event: websocket closed, user: 5b01d595-5022-4c42-9250-9bb88fc60cdd
```

Closes #24 