### PR TITLE
#42: Add JWT parsing to protect routes

### DIFF
--- a/client/src/components/Chat.tsx
+++ b/client/src/components/Chat.tsx
@@ -14,7 +14,7 @@ const Chat: React.FC = () => {
   const [lastMessage, setLastMessage] = useState<Message>({ sender: '', msg: '' });
 
   const createSocket = async (name: string) => {
-    const url = process.env.NODE_ENV === 'development' ? 'http://localhost:8080' : window.location.host;
+    const url = process.env.NODE_ENV === 'development' ? 'localhost:8080' : window.location.host;
     const ws = new WebSocket(`ws://${url}/api/connect/${name}`);
 
     ws.onopen = () => {

--- a/server/.env.test
+++ b/server/.env.test
@@ -1,0 +1,2 @@
+JWT_SECRET=some16bytehexcode
+DATABASE_URL=mysql://fakeconnectionstring

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
     '@typescript-eslint/no-shadow': ['error'],
     'import/no-unresolved': 'off', // handled by typescript
     'import/prefer-default-export': 'off',
+    'max-len': ['error', { code: 120, ignoreRegExpLiterals: true }],
     'import/extensions': 'off',
     'no-shadow': 'off',
   },

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   setupFilesAfterEnv: ['./src/prismaMock.ts'],
+  testRegex: 'src/spec/.*\\.ts$',
 };

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "dev": "NODE_ENV=development ts-node-dev ./src/server.ts",
+    "dev": "NODE_ENV=development ts-node-dev --no-notify --exit-child ./src/server.ts",
     "prod": "tsc && NODE_ENV=production pm2 startOrRestart pm2.config.js",
     "compile": "tsc",
     "lint": "eslint src --ext .js,.ts",
@@ -11,11 +11,11 @@
     "prisma:migrate:dev": "dotenv -e .env.development -- prisma migrate dev",
     "prisma:migrate:prod": "dotenv -e .env.production -- prisma migrate dev",
     "prisma:studio": "prisma studio",
-    "test": "jest -i"
+    "test": "dotenv -e .env.test -- jest -i"
   },
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "^3.9.1",
+    "@prisma/client": "^3.9.2",
     "argon2": "^0.28.4",
     "body-parser": "^1.19.1",
     "chai": "^4.3.6",
@@ -30,7 +30,7 @@
     "jest-mock-extended": "^2.0.4",
     "jsonwebtoken": "^8.5.1",
     "nodemon": "2.0.3",
-    "prisma": "^3.9.0",
+    "prisma": "^3.9.2",
     "supertest": "^6.2.2",
     "uuid": "^8.3.2",
     "ws": "^8.4.2",

--- a/server/prisma/migrations/20220210202241_add_password_changed_at_for_users/migration.sql
+++ b/server/prisma/migrations/20220210202241_add_password_changed_at_for_users/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `User` ADD COLUMN `passwordChangedAt` DATETIME(3) NULL;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -11,13 +11,14 @@ datasource db {
 }
 
 model User {
-  id        Int      @id @default(autoincrement())
-  email     String   @unique
-  username  String   @unique
-  password  String
-  role      Role     @default(USER)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id                Int       @id @default(autoincrement())
+  email             String    @unique
+  username          String    @unique
+  password          String
+  role              Role      @default(USER)
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+  passwordChangedAt DateTime?
 
   Results Result[]
 }

--- a/server/src/@types/global.d.ts
+++ b/server/src/@types/global.d.ts
@@ -1,0 +1,9 @@
+import { User } from '@prisma/client';
+
+declare global {
+    namespace Express {
+        interface Request {
+            user?: User
+        }
+    }
+}

--- a/server/src/errors/apiError.ts
+++ b/server/src/errors/apiError.ts
@@ -1,0 +1,26 @@
+import { StatusCodes } from 'http-status-codes';
+
+/**
+ * Used for creating API Errors.
+ * These errors can be caused by a malformed request, an internal server error, a failed database
+ * operation, the client trying to access a resource which they do not have the authorization for,
+ * the client trying to access a resource which does not exist, etc...
+ */
+class APIError extends Error {
+  /**
+   * The HTTP status code that will be sent in the response
+   */
+  statusCode: StatusCodes;
+
+  constructor(message: string, statusCode: StatusCodes) {
+    super(message);
+
+    this.statusCode = statusCode;
+    this.message = message;
+
+    // Prevents APIError objects from being implicitly casted to Error
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export default APIError;

--- a/server/src/errors/fieldError.ts
+++ b/server/src/errors/fieldError.ts
@@ -1,0 +1,24 @@
+class FieldError {
+  /**
+   * The field that has been violated
+   */
+  field: string;
+
+  /**
+   * The input that caused the error
+   */
+  input: string;
+
+  /**
+   * A message describing why the input is invalid for the field
+   */
+  message: string;
+
+  constructor(field: string, input: string, message: string) {
+    this.field = field;
+    this.input = input;
+    this.message = message;
+  }
+}
+
+export default FieldError;

--- a/server/src/middlewares/authMiddleware.ts
+++ b/server/src/middlewares/authMiddleware.ts
@@ -1,0 +1,74 @@
+import { Role } from '@prisma/client';
+import { Request, Response, NextFunction } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import jwt, { JsonWebTokenError } from 'jsonwebtoken';
+
+import env from '../config/environment';
+import APIError from '../errors/apiError';
+import { getUserById } from '../models/user';
+
+export const createJWT = (userId: number, res: Response) => {
+  const { secret, expiryTime, secure } = env.jwt;
+
+  const token = jwt.sign({ id: userId }, secret, { expiresIn: expiryTime });
+  const cookieOptions = {
+    expires: new Date(Date.now() + 1000 * expiryTime),
+    httpOnly: true,
+    secure,
+  };
+
+  res.cookie('Bearer', token, cookieOptions);
+};
+
+const validateJWT = (authHeader?: string) => {
+  if (!authHeader) return { token: null, error: new JsonWebTokenError('no token provided') };
+
+  // Verify that the authorization header used a Bearer token
+  // Splitting the header on a space will give us an array like this -> [TokenType, Token]
+  const [tokenType, token] = authHeader.split(' ');
+  if (tokenType !== 'Bearer') {
+    return { token: null, error: new JsonWebTokenError('invalid token type') };
+  }
+
+// Verify that the token is valid (no tampering) and that the decoded token has an id property
+type DecodedToken = { id: number; iat: number; exp: number };
+const decodedToken = jwt.verify(token, env.jwt.secret) as DecodedToken;
+if (typeof decodedToken !== 'object' || !decodedToken.id || !decodedToken.iat) {
+  return { token: null, error: new JsonWebTokenError('invalid token') };
+}
+
+return { token: decodedToken, error: null };
+};
+
+const checkPermissions = (userRole: Role, requiredRole: Role) => {
+  if (userRole === Role.ADMIN) return true;
+  if (userRole === Role.USER) return requiredRole === Role.USER;
+
+  return false;
+};
+
+export const protectRoute = (minRole: Role) => async (req: Request, _: Response, next: NextFunction) => {
+  const { authorization } = req.headers;
+
+  try {
+    const { token, error } = validateJWT(authorization);
+    if (error) return next(error);
+    if (!token?.id) return next(new JsonWebTokenError('no user id on token'));
+
+    const { data: user } = await getUserById(token.id);
+    if (!user) return next(new JsonWebTokenError('user in token does not exist'));
+
+    if (user.passwordChangedAt && user.passwordChangedAt.getTime() > token.iat) {
+      return next(new JsonWebTokenError('token expired'));
+    }
+
+    if (!checkPermissions(user.role, minRole)) {
+      return next(new APIError('unauthorized to perform this action', StatusCodes.FORBIDDEN));
+    }
+
+    req.user = user;
+    return next();
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/server/src/middlewares/errorMiddleware.ts
+++ b/server/src/middlewares/errorMiddleware.ts
@@ -1,0 +1,35 @@
+import { NextFunction, Request, Response } from 'express';
+import { JsonWebTokenError } from 'jsonwebtoken';
+import { StatusCodes } from 'http-status-codes';
+import APIError from '../errors/apiError';
+
+/**
+ * Catches errors in the express middleware and sends details about them as a response,
+ * All 4 parameters are required since that is how express differentiates between normal
+ * middleware and error handling middleware
+ * @param err The http exception
+ * @param _req Incoming request, UNUSED
+ * @param res Outgoing Response
+ * @param next Calls the next middleware, UNUSED
+ */
+function handleError(err: Error, _: Request, res: Response, next: NextFunction) {
+  let status;
+  let message;
+
+  // Handle the error based on what kind of error is received
+  if (err instanceof APIError) {
+    status = err.statusCode;
+    message = err.message;
+  } else if (err instanceof JsonWebTokenError) {
+    status = StatusCodes.UNAUTHORIZED;
+    message = err.message;
+  } else {
+    status = StatusCodes.INTERNAL_SERVER_ERROR;
+    message = 'unknown error';
+  }
+
+  res.status(status).send({ data: null, errors: [message] });
+  next();
+}
+
+export default handleError;

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -1,6 +1,8 @@
 import { User } from '@prisma/client';
+import { StatusCodes } from 'http-status-codes';
+import FieldError from '../errors/fieldError';
 import db from '../prismaClient';
-import { classifyPrismaError, FieldError } from '../utils/errors';
+import { classifyPrismaError } from '../utils/errors';
 
 interface SignupInput {
   email: string
@@ -13,67 +15,76 @@ const USERNAME_REGEX = /^[a-z0-9_-]{0,16}$/;
 const PASSWORD_REGEX = /^.*(?=.{8,32})(?=.*[a-zA-Z])(?=.*\d).*$/;
 
 const validateEmailForSignup = async (email: any) => {
-  const errors: FieldError[] = [];
+  const errors = [];
+  let status = StatusCodes.CREATED;
 
   if (!email) {
-    errors.push({ field: 'email', input: email, message: 'must be present' });
+    errors.push(new FieldError('email', email, 'must be present'));
   } else if (typeof email !== 'string') {
-    errors.push({ field: 'email', input: email, message: 'must be a string' });
+    errors.push(new FieldError('email', email, 'must be a string'));
   } else if (!EMAIL_REGEX.test(email)) {
-    errors.push({ field: 'email', input: email, message: 'must be a valid email address' });
+    errors.push(new FieldError('email', email, 'must be a valid email address'));
   }
 
-  if (errors.length > 0) return errors;
+  if (errors.length > 0) return { errors, status: StatusCodes.UNPROCESSABLE_ENTITY };
 
   const existingUser = await db.user.findUnique({ where: { email } });
-  if (existingUser) errors.push({ field: 'email', input: email, message: 'is already taken' });
+  if (existingUser) {
+    errors.push(new FieldError('email', email, 'is already taken'));
+    status = StatusCodes.CONFLICT;
+  }
 
-  return errors;
+  return { errors, status };
 };
 
 const validateUsernameForSignup = async (username: any) => {
-  const errors: FieldError[] = [];
+  const errors = [];
+  let status = StatusCodes.CREATED;
 
   if (!username) {
-    errors.push({ field: 'username', input: username, message: 'must be present' });
+    errors.push(new FieldError('username', username, 'must be present'));
   } else if (typeof username !== 'string') {
-    errors.push({ field: 'username', input: username, message: 'must be a string' });
+    errors.push(new FieldError('username', username, 'must be a string'));
   } else if (!USERNAME_REGEX.test(username)) {
-    errors.push({ field: 'username', input: username, message: 'must be a valid username' });
+    errors.push(new FieldError('username', username, 'must be a valid username'));
   }
 
-  if (errors.length > 0) return errors;
+  if (errors.length > 0) return { errors, status: StatusCodes.UNPROCESSABLE_ENTITY };
 
   const existingUser = await db.user.findUnique({ where: { username } });
-  if (existingUser) errors.push({ field: 'username', input: username, message: 'is already taken' });
+  if (existingUser) {
+    errors.push(new FieldError('username', username, 'is already taken'));
+    status = StatusCodes.CONFLICT;
+  }
 
-  return errors;
+  return { errors, status };
 };
 
 const validatePassword = (password: any) => {
-  const errors: FieldError[] = [];
+  const errors = [];
 
   if (!password) {
-    errors.push({ field: 'password', input: password, message: 'must be present' });
+    errors.push(new FieldError('password', password, 'must be present'));
   } else if (typeof password !== 'string') {
-    errors.push({ field: 'password', input: password, message: 'must be a string' });
+    errors.push(new FieldError('password', password, 'must be a string'));
   } else if (!PASSWORD_REGEX.test(password)) {
-    errors.push({ field: 'password', input: password, message: 'must be a valid password' });
+    errors.push(new FieldError('password', password, 'must be a valid password'));
   }
 
-  return errors;
+  return { errors, status: errors.length > 0 ? StatusCodes.UNPROCESSABLE_ENTITY : StatusCodes.OK };
 };
 
 const validateIdentifierForLogin = async (identifier: any) => {
-  let errors: FieldError[] = [];
+  const errors = [];
+  let status = StatusCodes.OK;
 
   if (!identifier) {
-    errors.push({ field: 'email/username', input: identifier, message: 'must be present' });
+    errors.push(new FieldError('email/username', identifier, 'must be present'));
   } else if (typeof identifier !== 'string') {
-    errors.push({ field: 'email/username', input: identifier, message: 'must be a string' });
+    errors.push(new FieldError('email/username', identifier, 'must be a string'));
   }
 
-  if (errors.length > 0) return { data: null, errors };
+  if (errors.length > 0) return { data: null, errors, status: StatusCodes.UNPROCESSABLE_ENTITY };
 
   // Determine whether the identifier is an email, username, or neither
   let identifierField: 'email' | 'username' | null = null;
@@ -81,34 +92,39 @@ const validateIdentifierForLogin = async (identifier: any) => {
   else if (USERNAME_REGEX.test(identifier)) identifierField = 'username';
 
   if (!identifierField) {
-    errors = [{ field: 'email/username', input: identifier, message: 'must be a valid identifier' }];
-    return { data: null, errors };
+    return {
+      data: null,
+      errors: [new FieldError('email/username', identifier, 'must be a valid identifier')],
+      status: StatusCodes.UNPROCESSABLE_ENTITY,
+    };
   }
 
-  if (errors.length > 0) return { data: null, errors };
-
   const existingUser = await db.user.findUnique({ where: { [identifierField]: identifier } });
-  if (!existingUser) errors.push({ field: identifierField, input: identifier, message: 'is not associated with an account' });
+  if (!existingUser) {
+    errors.push(new FieldError(identifierField, identifier, 'is not associated with an account'));
+    status = StatusCodes.NOT_FOUND;
+  }
 
-  return { data: existingUser, errors };
+  return { data: existingUser, errors, status };
 };
 
 export const validateSignupInput = async (data: any) => {
   const { email, username, password } = data;
 
   let errors: FieldError[] = [];
-  errors = [...errors, ...(await validateEmailForSignup(email))];
-  errors = [...errors, ...(await validateUsernameForSignup(username))];
-  errors = [...errors, ...validatePassword(password)];
+  const { errors: emailErrors, status: emailStatus } = await validateEmailForSignup(email);
+  const { errors: usernameErrors, status: usernameStatus } = await validateUsernameForSignup(username);
+  const { errors: passwordErrors, status: passwordStatus } = validatePassword(password);
 
-  return errors;
+  errors = [...errors, ...emailErrors, ...usernameErrors, ...passwordErrors];
+
+  return { errors, status: Math.max(emailStatus, usernameStatus, passwordStatus) };
 };
 
 export const validateLoginInput = async (input: any) => {
   const { identifier } = input;
 
-  const { data, errors } = await validateIdentifierForLogin(identifier);
-  return { data, errors };
+  return validateIdentifierForLogin(identifier);
 };
 
 // Removes fields that should not be included in an HTTP response
@@ -130,5 +146,14 @@ export const signupUser = async (inputUser: SignupInput) => {
     return { data: newUser, error: null };
   } catch (e) {
     return { data: null, error: classifyPrismaError(e) };
+  }
+};
+
+export const getUserById = async (id: number) => {
+  try {
+    const user = await db.user.findUnique({ where: { id } });
+    return { data: user, error: null };
+  } catch (error) {
+    return { data: null, error: classifyPrismaError(error) };
   }
 };

--- a/server/src/prismaMock.ts
+++ b/server/src/prismaMock.ts
@@ -8,8 +8,10 @@ jest.mock('./prismaClient', () => ({
   default: mockDeep<PrismaClient>(),
 }));
 
-export const dbMock = db as unknown as DeepMockProxy<PrismaClient>;
+const dbMock = db as unknown as DeepMockProxy<PrismaClient>;
 
 beforeEach(() => {
   mockReset(dbMock);
 });
+
+export default dbMock;

--- a/server/src/routes/apiRoutes.ts
+++ b/server/src/routes/apiRoutes.ts
@@ -1,0 +1,29 @@
+import { randomInt } from 'crypto';
+import express, { Request, Response } from 'express';
+import { StatusCodes } from 'http-status-codes';
+
+import APIError from '../errors/apiError';
+import { writeLog } from '../utils/log';
+
+import passageRoutes from './passageRoutes';
+import userRoutes from './userRoutes';
+
+const router = express.Router({ mergeParams: true });
+
+router.get('/random', (req: Request, res: Response) => {
+  writeLog({ event: 'logging request query', data: req.query }, 'info');
+  res.json(randomInt(100).toString());
+});
+
+router.use('/passages', passageRoutes);
+router.use('/users', userRoutes);
+
+// Funnel all routes that don't exist to a 404 NOT FOUND
+router.all('*', (req, _res, next) => next(
+  new APIError(
+    `${req.originalUrl} does not exist on this server`,
+    StatusCodes.NOT_FOUND,
+  ),
+));
+
+export default router;

--- a/server/src/routes/passageRoutes.ts
+++ b/server/src/routes/passageRoutes.ts
@@ -1,8 +1,12 @@
+import { Role } from '@prisma/client';
 import express from 'express';
+
 import { handleCreatePassage } from '../controllers/passageController';
+import { protectRoute } from '../middlewares/authMiddleware';
 
 const router = express.Router({ mergeParams: true });
 
+router.use(protectRoute(Role.ADMIN));
 router.route('/').post(handleCreatePassage);
 
 export default router;

--- a/server/src/utils/errors.ts
+++ b/server/src/utils/errors.ts
@@ -9,12 +9,6 @@ import { StatusCodes } from 'http-status-codes';
 
 import { writeLog } from './log';
 
-export interface FieldError {
-  field: string
-  input: string
-  message: string
-}
-
 interface PrismaError {
     message: string
     httpStatus: number

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "ts-node": {
+    "files": true
+  },
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,10 +778,10 @@
   dependencies:
     debug "^4.3.1"
 
-"@prisma/client@^3.9.1":
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.9.1.tgz#565c8121f1220637bcab4a1d1f106b8c1334406c"
-  integrity sha512-aLwfXKLvL+loQ0IuPPCXkcq8cXBg1IeoHHa5lqQu3dJHdj45wnislA/Ny4UxRQjD5FXqrfAb8sWtF+jhdmjFTg==
+"@prisma/client@^3.9.2":
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.9.2.tgz#ad17dcfb702842573fe6ec3b7dc4615eff8d8fc6"
+  integrity sha512-VlEIYVMyfFZHbVBOlunPl47gmP/Z0zzPjPj8I7uKEIaABqrUy50ru3XS0aZd8GFvevVwt7p91xxkUjNjrWhKAQ==
   dependencies:
     "@prisma/engines-version" "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
 
@@ -1838,7 +1838,22 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
-chokidar@^3.2.2, chokidar@^3.5.1, chokidar@^3.5.2:
+chokidar@^3.2.2:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+chokidar@^3.5.1, chokidar@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
   integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
@@ -5303,10 +5318,10 @@ pretty-format@^27.0.0, pretty-format@^27.5.0:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-prisma@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.9.0.tgz#7aea4e35b385b980fef3c4a5a15c82b034a31006"
-  integrity sha512-KppIukAgJH6o4q9CRYQUqpJUFt8XOK+5eTlv9W+w/SnaSzar+zbT7RCxspCkoGGVSASAQDMYWSKm3QON/o5ENg==
+prisma@^3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.9.2.tgz#cc2da4e8db91231dea7465adf9db6e19f11032a9"
+  integrity sha512-i9eK6cexV74OgeWaH3+e6S07kvC9jEZTl6BqtBH398nlCU0tck7mE9dicY6YQd+euvMjjCtY89q4NgmaPnUsSg==
   dependencies:
     "@prisma/engines" "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
 


### PR DESCRIPTION
## Big Changes
1. The important block of code here is the `protectRoute()` method in `authMiddleware.ts`. This middleware can be placed before any routes that we want to protect, either to check authentication or authorization. I also added an example use case of it in `passageRoutes.ts`.
2. Override the default express error handling middleware
3. Added 2 new error types APIError, and FieldError 