### PR TITLE
#50: Setup reset password flow

### DIFF
--- a/client/src/components/ForgotPassword.tsx
+++ b/client/src/components/ForgotPassword.tsx
@@ -1,28 +1,42 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import {
   Button, Group, TextInput,
 } from '@mantine/core';
-import { emailValidator } from '@utils/validators';
+import { blankValidator } from '@utils/validators';
 import { useForm } from '@mantine/hooks';
-import { IoAt } from 'react-icons/io5';
+import { IoPerson } from 'react-icons/io5';
+import axios from '../config/axios';
 
 const ForgotPassword: React.FC = () => {
   const form = useForm({
-    initialValues: { email: '' },
-    validationRules: { email: (value) => emailValidator(value) },
-    errorMessages: { email: 'email must be a valid' },
+    initialValues: { identifier: '' },
+    validationRules: { identifier: (value) => blankValidator(value) },
+    errorMessages: { identifier: 'identifier must be valid' },
   });
 
+  const handleSubmit = async (values: typeof form.values) => {
+    try {
+      await axios.post('/users/password-reset-email', { ...values });
+    } catch (err) {
+      // TODO
+    }
+  };
+
   return (
-    <form onSubmit={form.onSubmit(() => {})}>
+    <form onSubmit={form.onSubmit(handleSubmit)}>
       <Group direction="column" align="stretch">
-        <TextInput label="Email Address" placeholder="Your email address" icon={<IoAt />} {...form.getInputProps('email')} required />
+        <TextInput
+          label="Username or Email Address"
+          required
+          icon={<IoPerson />}
+          placeholder="Your username or email"
+          {...form.getInputProps('identifier')}
+        />
         <Group position="apart">
           <div />
-          <Button>Send Email</Button>
+          <Button type="submit">Send Email</Button>
         </Group>
-
       </Group>
     </form>
   );

--- a/client/src/components/ResetPassword.tsx
+++ b/client/src/components/ResetPassword.tsx
@@ -1,0 +1,67 @@
+import {
+  Button, Group, Paper, TextInput, Title,
+} from '@mantine/core';
+import { useForm } from '@mantine/hooks';
+import { passwordValidator } from '@utils/validators';
+import axios from 'axios';
+import React from 'react';
+import { IoLockClosed } from 'react-icons/io5';
+import { useParams } from 'react-router';
+
+const ResetPassword: React.FC = () => {
+  const { token } = useParams();
+
+  const form = useForm({
+    initialValues: {
+      password: '',
+      confirmPassword: '',
+    },
+    errorMessages: {
+      password: 'password is too weak',
+      confirmPassword: 'passwords do not match',
+    },
+    validationRules: {
+      password: (value) => passwordValidator(value),
+      confirmPassword: (value, values) => value === values?.confirmPassword,
+    },
+  });
+
+  const handleSubmit = async (values: typeof form.values) => {
+    try {
+      await axios.post('/users/password-reset', { token, password: values.password });
+    } catch (err) {
+      // TODO
+    }
+  };
+
+  return (
+    <Paper shadow="lg" padding="lg">
+      <Title order={4}>Reset your Password</Title>
+      <form onSubmit={form.onSubmit(handleSubmit)}>
+        <Group direction="column">
+          <TextInput
+            icon={<IoLockClosed />}
+            label="Password"
+            placeholder="Password"
+            onBlur={() => form.validateField('password')}
+            type="password"
+            required
+            {...form.getInputProps('password')}
+          />
+          <TextInput
+            icon={<IoLockClosed />}
+            label="Confirm Password"
+            placeholder="Confirm Password"
+            onBlur={() => form.validateField('confirmPassword')}
+            type="password"
+            required
+            {...form.getInputProps('confirmPassword')}
+          />
+          <Button type="submit">Reset Password</Button>
+        </Group>
+      </form>
+    </Paper>
+  );
+};
+
+export default ResetPassword;

--- a/client/src/components/Router.tsx
+++ b/client/src/components/Router.tsx
@@ -3,12 +3,14 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import TypingZone from '@components/TypingZone';
 import Chat from '@components/Chat';
+import ResetPassword from '@components/ResetPassword';
 
 const Router: React.FC = () => (
   <BrowserRouter>
     <Routes>
       <Route path="/" element={<TypingZone />} />
       <Route path="/hello" element={<Chat />} />
+      <Route path="/reset-password/:token" element={<ResetPassword />} />
     </Routes>
   </BrowserRouter>
 );

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -2,6 +2,6 @@ module.exports = {
   clearMocks: true,
   preset: 'ts-jest',
   testEnvironment: 'node',
-  setupFilesAfterEnv: ['./src/prismaMock.ts'],
+  setupFilesAfterEnv: ['./src/spec/prismaMock.ts'],
   testRegex: 'src/spec/.*\\.spec\\.ts$',
 };

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@prisma/client": "^3.9.2",
+    "@sendgrid/mail": "^7.6.1",
     "argon2": "^0.28.4",
     "body-parser": "^1.19.1",
     "chai": "^4.3.6",

--- a/server/prisma/migrations/20220308035308_add_password_reset_token_table/migration.sql
+++ b/server/prisma/migrations/20220308035308_add_password_reset_token_table/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE `PasswordResetToken` (
+    `id` VARCHAR(191) NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `expiresAt` DATETIME(3) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `PasswordResetToken` ADD CONSTRAINT `PasswordResetToken_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -20,7 +20,8 @@ model User {
   updatedAt         DateTime  @updatedAt
   passwordChangedAt DateTime?
 
-  Results Result[]
+  Results            Result[]
+  PasswordResetToken PasswordResetToken[]
 }
 
 model Passage {
@@ -52,6 +53,14 @@ model Result {
 
   @@unique([userId, raceId])
   @@index([userId])
+}
+
+model PasswordResetToken {
+  id        String   @id @default(uuid())
+  userId    Int
+  expiresAt DateTime
+
+  User User @relation(fields: [userId], references: [id])
 }
 
 enum Role {

--- a/server/src/config/environment.ts
+++ b/server/src/config/environment.ts
@@ -13,10 +13,18 @@ interface JWTConfig {
   secure: boolean;
 }
 
+interface MailerConfig {
+  apiKey: string
+  username: string
+  resetPasswordTemplateId: string
+}
+
 interface Environment {
+  baseClientUrl: string,
   clientUrls: string[];
   rateLimits: RateLimitConfig[];
   jwt: JWTConfig;
+  mailer?: MailerConfig // Wont exist in development
 }
 
 // Must load the .env file before initializing the environment
@@ -24,6 +32,7 @@ dotenv.config({ path: `${__dirname}/../../.env.${process.env.NODE_ENV as NodeEnv
 
 const environment: { [_ in NodeEnv]: Environment } = {
   development: {
+    baseClientUrl: 'http://localhost:3000',
     clientUrls: ['http://localhost:3000'],
     rateLimits: [
       {
@@ -42,6 +51,7 @@ const environment: { [_ in NodeEnv]: Environment } = {
     },
   },
   production: {
+    baseClientUrl: 'http://3.16.27.120:8080',
     clientUrls: [],
     rateLimits: [
       {
@@ -57,6 +67,11 @@ const environment: { [_ in NodeEnv]: Environment } = {
       secret: process.env.JWT_SECRET!,
       expiryTime: 60 * 60 * 24 * 7, // 7 Days
       secure: true,
+    },
+    mailer: {
+      apiKey: process.env.MAILER_API_KEY!,
+      username: process.env.MAILER_USERNAME!,
+      resetPasswordTemplateId: 'd-803b3420888a4b16be882f3231efbc65',
     },
   },
 };

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -9,7 +9,12 @@ import {
   signupUser,
   validateLoginInput,
   sanitizeUserOutput,
+  validateSendResetPasswordInput,
+  createResetPasswordToken,
+  validateResetPasswordInput,
+  resetPassword,
 } from '../models/user';
+import sendResetPasswordEmail from '../utils/mailer';
 
 export const handleSignupUser = async (req: Request, res: Response) => {
   const { body } = req;
@@ -42,4 +47,26 @@ export const handleLoginUser = async (req: Request, res: Response) => {
   res.status(StatusCodes.OK).json(
     { data: sanitizeUserOutput(user), errors: [] },
   );
+};
+
+export const handleResetPasswordEmail = async (req: Request, res: Response) => {
+  const { body } = req;
+
+  const user = await validateSendResetPasswordInput(body);
+  const token = await createResetPasswordToken(user);
+
+  await sendResetPasswordEmail(user.email, token.id);
+
+  res.status(StatusCodes.OK).end();
+};
+
+export const handleResetPassword = async (req: Request, res: Response) => {
+  const { body } = req;
+
+  const resetToken = await validateResetPasswordInput(body);
+
+  const { password } = body;
+  await resetPassword(resetToken, password);
+
+  res.status(StatusCodes.ACCEPTED).end();
 };

--- a/server/src/errors/forbiddenError.ts
+++ b/server/src/errors/forbiddenError.ts
@@ -1,0 +1,11 @@
+import { StatusCodes } from 'http-status-codes';
+import APIError from './apiError';
+
+/**
+   * Utility to create 403 Forbidden Errors.
+   */
+export class ForbiddenError extends APIError {
+  constructor() {
+    super('unauthorized', StatusCodes.FORBIDDEN);
+  }
+}

--- a/server/src/errors/notFoundError.ts
+++ b/server/src/errors/notFoundError.ts
@@ -1,0 +1,11 @@
+import { StatusCodes } from 'http-status-codes';
+import APIError from './apiError';
+
+/**
+   * Utility to create 404 Not Found Errors.
+   */
+export class NotFoundError extends APIError {
+  constructor(entity: string) {
+    super(`${entity} not found`, StatusCodes.NOT_FOUND);
+  }
+}

--- a/server/src/errors/unauthenticatedError.ts
+++ b/server/src/errors/unauthenticatedError.ts
@@ -1,0 +1,11 @@
+import { StatusCodes } from 'http-status-codes';
+import APIError from './apiError';
+
+/**
+ * Utility to create 401 Unauthenticated Errors.
+ */
+export class UnauthenticatedError extends APIError {
+  constructor() {
+    super('unauthenticated', StatusCodes.UNAUTHORIZED);
+  }
+}

--- a/server/src/routes/userRoutes.ts
+++ b/server/src/routes/userRoutes.ts
@@ -1,10 +1,15 @@
 import express from 'express';
-import { handleLoginUser, handleSignupUser } from '../controllers/userController';
+import {
+  handleLoginUser, handleResetPassword, handleResetPasswordEmail, handleSignupUser,
+} from '../controllers/userController';
 import catchAsync from '../utils/catchAsync';
 
 const router = express.Router({ mergeParams: true });
 
 router.route('/signup').post(catchAsync(handleSignupUser));
 router.route('/login').post(catchAsync(handleLoginUser));
+
+router.route('/password-reset-email').post(catchAsync(handleResetPasswordEmail));
+router.route('/password-reset').post(catchAsync(handleResetPassword));
 
 export default router;

--- a/server/src/spec/models/user.spec.ts
+++ b/server/src/spec/models/user.spec.ts
@@ -12,7 +12,7 @@ import {
   validateSignupInput,
 } from '../../models/user';
 
-import dbMock from '../../prismaMock';
+import dbMock from '../prismaMock';
 import { expectThrowsAsync } from '../specUtils';
 
 describe('user', () => {

--- a/server/src/spec/prismaMock.ts
+++ b/server/src/spec/prismaMock.ts
@@ -1,9 +1,9 @@
 import { PrismaClient } from '@prisma/client';
 import { mockDeep, mockReset, DeepMockProxy } from 'jest-mock-extended';
 
-import db from './prismaClient';
+import db from '../prismaClient';
 
-jest.mock('./prismaClient', () => ({
+jest.mock('../prismaClient', () => ({
   __esModule: true,
   default: mockDeep<PrismaClient>(),
 }));

--- a/server/src/utils/mailer.ts
+++ b/server/src/utils/mailer.ts
@@ -1,0 +1,27 @@
+import SendGrid, { MailDataRequired } from '@sendgrid/mail';
+import environment from '../config/environment';
+import { writeLog } from './log';
+
+const sendResetPasswordEmail = async (to: string, token: string) => {
+  if (!environment.mailer) {
+    writeLog({ event: 'Reset Password', token }, 'info');
+    return;
+  }
+
+  const message: MailDataRequired = {
+    to,
+    from: environment.mailer.username,
+    subject: 'Reset Password',
+    templateId: environment.mailer.resetPasswordTemplateId,
+    dynamicTemplateData: {
+      host: environment.baseClientUrl,
+      token,
+    },
+
+  };
+
+  SendGrid.setApiKey(environment.mailer.apiKey);
+  await SendGrid.send(message);
+};
+
+export default sendResetPasswordEmail;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,6 +1023,29 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@sendgrid/client@^7.6.1":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-7.6.1.tgz#de17fe9f04af3bdb69aca44fc407316de87cea3b"
+  integrity sha512-q4U5OhcbJjs+lLVv/LhZSc28feiVCFMgvG9aYcRI5X4tKArnrrGDWb5HMITR9vaAtX42TXhyPFjHr1fk/Q1loQ==
+  dependencies:
+    "@sendgrid/helpers" "^7.6.0"
+    axios "^0.21.4"
+
+"@sendgrid/helpers@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-7.6.0.tgz#b381bfab391bcd66c771811b22bb6bb2d5c1dfc6"
+  integrity sha512-0uWD+HSXLl4Z/X3cN+UMQC20RE7xwAACgppnfjDyvKG0KvJcUgDGz7HDdQkiMUdcVWfmyk6zKSg7XKfKzBjTwA==
+  dependencies:
+    deepmerge "^4.2.2"
+
+"@sendgrid/mail@^7.6.1":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-7.6.1.tgz#f7bbfc93781b0b6126549bf4b3649805295b02aa"
+  integrity sha512-F+HXpDLIU4PGZyZznOiFLDGJDwLn2qh7/wD5MvwurrldDx5DaGQHrYBKHopceOl15FVuq9ElU9VIxQJF8SMvTg==
+  dependencies:
+    "@sendgrid/client" "^7.6.1"
+    "@sendgrid/helpers" "^7.6.0"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1709,7 +1732,7 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5"
   integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==
 
-axios@^0.21.0:
+axios@^0.21.0, axios@^0.21.4:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==


### PR DESCRIPTION
## Summary of Changes
1. Add a table `PasswordResetTokens` which stores reset tokens and which users they are associated with
2. Add a handler for `/users/password-reset-email` that creates a password reset token, and send an email to the users account (if it exists).
3. Setup SendGrid API for sending emails over SMTP (We have a 100 emails per day limit)
4. Add a handler for `/users/password-reset` that takes a token and a new password and updates the password of the user associated with the token.
> the token is only sent to the users email address and would be impossible to otherwise guess
5. Add a UI form for resetting a password.

Main thing to note here is that you'll need to add the API key to your .env.production file.
Also because we're limited to how many emails we can send I'm making it a production only feature.

In development, instead of sending an email, the token will be written to the console.

Closes #50 