### PR TITLE
#52: UI home page and auth separation

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "@mantine/core": "^3.6.14",
     "@mantine/hooks": "^3.6.14",
     "@mantine/modals": "^3.6.14",
+    "@mantine/notifications": "^3.6.14",
     "axios": "^0.24.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import axios from '@config/axios';
 import Navigation from '@components/Navigation';
 import { ModalsProvider } from '@mantine/modals';
 import { Button, Group } from '@mantine/core';
+import { NotificationsProvider } from '@mantine/notifications';
 
 const App: React.FC = () => {
   const [randomServerNumber, setRandomServerNumber] = useState(null);
@@ -15,18 +16,20 @@ const App: React.FC = () => {
   };
 
   return (
-    <ModalsProvider>
-      <Navigation />
-      <Group direction="column" align="center" mt={16}>
-        <Router />
-        <Button mt={16} onClick={sendRequest}>
-          Click Me to Ping the API
-        </Button>
-        {randomServerNumber && (
-        <div>{randomServerNumber}</div>
-        )}
-      </Group>
-    </ModalsProvider>
+    <NotificationsProvider>
+      <ModalsProvider>
+        <Navigation />
+        <Group direction="column" align="center" mt={16}>
+          <Router />
+          <Button mt={16} onClick={sendRequest}>
+            Click Me to Ping the API
+          </Button>
+          {randomServerNumber && (
+            <div>{randomServerNumber}</div>
+          )}
+        </Group>
+      </ModalsProvider>
+    </NotificationsProvider>
   );
 };
 

--- a/client/src/components/ForgotPassword.tsx
+++ b/client/src/components/ForgotPassword.tsx
@@ -5,7 +5,8 @@ import {
 } from '@mantine/core';
 import { blankValidator } from '@utils/validators';
 import { useForm } from '@mantine/hooks';
-import { IoPerson } from 'react-icons/io5';
+import { IoCheckmark, IoClose, IoPerson } from 'react-icons/io5';
+import { useNotifications } from '@mantine/notifications';
 import axios from '../config/axios';
 
 const ForgotPassword: React.FC = () => {
@@ -15,11 +16,34 @@ const ForgotPassword: React.FC = () => {
     errorMessages: { identifier: 'identifier must be valid' },
   });
 
+  const notifications = useNotifications();
+
   const handleSubmit = async (values: typeof form.values) => {
     try {
       await axios.post('/users/password-reset-email', { ...values });
-    } catch (err) {
-      // TODO
+
+      notifications.showNotification({
+        title: 'Email Sent!',
+        color: 'green',
+        icon: <IoCheckmark />,
+        message: 'You should see the email in your inbox shortly',
+      });
+    } catch (err: any) {
+      const resError = err?.response?.data?.error;
+      if (!resError) {
+        notifications.showNotification({
+          title: 'Uh Oh!',
+          color: 'red',
+          icon: <IoClose />,
+          message: 'Something went wrong here...',
+        });
+      } else {
+        const { fieldErrors } = resError;
+        fieldErrors.forEach((fieldError: {field: typeof form.values, message: string}) => {
+          const { field, message } = fieldError;
+          form.setFieldError('identifier', `${field} ${message}`);
+        });
+      }
     }
   };
 

--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -1,0 +1,42 @@
+import {
+  Button, Card, Container, Grid, Group, Title, useMantineTheme,
+} from '@mantine/core';
+import React from 'react';
+
+const Home: React.FC = () => {
+  const { colors } = useMantineTheme();
+  const whiteBg = { backgroundColor: colors.gray[0] };
+
+  return (
+    <Container>
+      <Grid>
+        <Grid.Col span={12}>
+          <Card style={whiteBg}>
+            <Group direction="column" spacing="xs">
+              <Title order={4}>Race Opponents from Around the World</Title>
+              <Button>Join a Typing Race</Button>
+            </Group>
+          </Card>
+        </Grid.Col>
+        <Grid.Col span={6}>
+          <Card style={whiteBg}>
+            <Group direction="column" spacing="xs">
+              <Title order={5}>Improve your typing skills alone</Title>
+              <Button color="cyan">Practice Typing Alone</Button>
+            </Group>
+          </Card>
+        </Grid.Col>
+        <Grid.Col span={6}>
+          <Card style={whiteBg}>
+            <Group direction="column" spacing="xs">
+              <Title order={5}>Create a room and invite your friends</Title>
+              <Button color="cyan">Race your friends</Button>
+            </Group>
+          </Card>
+        </Grid.Col>
+      </Grid>
+    </Container>
+  );
+};
+
+export default Home;

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import {
-  Button, Group, Header, Title,
+  Button, Group, Header, Title, Text, Badge,
 } from '@mantine/core';
 
 import { useModals } from '@mantine/modals';
 import { AuthModals, AuthType } from '@components/AuthForm';
+import { IoSettings, IoStatsChart } from 'react-icons/io5';
+import axios from 'axios';
 
 const Navigation: React.FC = () => {
   const modals = useModals();
@@ -13,14 +15,44 @@ const Navigation: React.FC = () => {
     modals.openModal(AuthModals[type]);
   };
 
+  const logoutUser = async () => {
+    try {
+      await axios.get('/users/logout');
+      localStorage.removeItem('user');
+      window.location.href = '/';
+    } catch (err) {
+      // TODO
+    }
+  };
+
+  const lsUser = localStorage.getItem('user');
+  const user = lsUser ? JSON.parse(lsUser) : null;
+
   return (
     <Header height={50}>
       <Group position="apart" spacing="xs">
         <Title order={2}>TypeTrial</Title>
-        <Group>
-          <Button size="md" variant="light" onClick={() => openAuthModal('login')}>Login</Button>
-          <Button size="md" onClick={() => openAuthModal('signup')}>Sign Up</Button>
-        </Group>
+        { user ? (
+          <Group spacing="sm">
+            <Group spacing={8}>
+              <Group direction="column" spacing={0} align="center">
+                <Text size="sm" weight="bold">{user.username}</Text>
+                <Group spacing={2}>
+                  <Badge size="xs">WPM: 0</Badge>
+                  <Badge size="xs">Races: 0</Badge>
+                </Group>
+              </Group>
+              <Button size="md" color="blue" variant="light"><IoStatsChart /></Button>
+              <Button size="md" color="gray" variant="light"><IoSettings /></Button>
+            </Group>
+            <Button color="gray" variant="light" size="md" onClick={logoutUser}>Logout</Button>
+          </Group>
+        ) : (
+          <Group>
+            <Button size="md" variant="light" onClick={() => openAuthModal('login')}>Login</Button>
+            <Button size="md" onClick={() => openAuthModal('signup')}>Sign Up</Button>
+          </Group>
+        )}
       </Group>
     </Header>
   );

--- a/client/src/components/Router.tsx
+++ b/client/src/components/Router.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
-import TypingZone from '@components/TypingZone';
 import Chat from '@components/Chat';
+import Home from '@components/Home';
 import ResetPassword from '@components/ResetPassword';
 
 const Router: React.FC = () => (
   <BrowserRouter>
     <Routes>
-      <Route path="/" element={<TypingZone />} />
+      <Route path="/" element={<Home />} />
       <Route path="/hello" element={<Chat />} />
       <Route path="/reset-password/:token" element={<ResetPassword />} />
     </Routes>

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -18,7 +18,6 @@ import sendResetPasswordEmail from '../utils/mailer';
 
 export const handleSignupUser = async (req: Request, res: Response) => {
   const { body } = req;
-
   await validateSignupInput(body);
 
   const { email, username, password } = body;
@@ -28,7 +27,7 @@ export const handleSignupUser = async (req: Request, res: Response) => {
   const newUser = await signupUser(inputUser);
 
   createJWT(newUser.id, res);
-  res.status(StatusCodes.CREATED).json({ data: sanitizeUserOutput(newUser), errors: [] });
+  res.status(StatusCodes.CREATED).json({ user: sanitizeUserOutput(newUser), errors: [] });
 };
 
 export const handleLoginUser = async (req: Request, res: Response) => {
@@ -45,7 +44,7 @@ export const handleLoginUser = async (req: Request, res: Response) => {
 
   createJWT(user.id, res);
   res.status(StatusCodes.OK).json(
-    { data: sanitizeUserOutput(user), errors: [] },
+    { user: sanitizeUserOutput(user), errors: [] },
   );
 };
 
@@ -69,4 +68,11 @@ export const handleResetPassword = async (req: Request, res: Response) => {
   await resetPassword(resetToken, password);
 
   res.status(StatusCodes.ACCEPTED).end();
+};
+
+export const handleLogoutUser = async (_: Request, res: Response) => {
+  res
+    .cookie('Bearer', 'logged_out', { maxAge: 10 * 1000, httpOnly: true, secure: false })
+    .status(StatusCodes.OK)
+    .end();
 };

--- a/server/src/routes/userRoutes.ts
+++ b/server/src/routes/userRoutes.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import {
-  handleLoginUser, handleResetPassword, handleResetPasswordEmail, handleSignupUser,
+  handleLoginUser, handleLogoutUser, handleResetPassword, handleResetPasswordEmail, handleSignupUser,
 } from '../controllers/userController';
 import catchAsync from '../utils/catchAsync';
 
@@ -8,6 +8,7 @@ const router = express.Router({ mergeParams: true });
 
 router.route('/signup').post(catchAsync(handleSignupUser));
 router.route('/login').post(catchAsync(handleLoginUser));
+router.route('/logout').get(handleLogoutUser);
 
 router.route('/password-reset-email').post(catchAsync(handleResetPasswordEmail));
 router.route('/password-reset').post(catchAsync(handleResetPassword));

--- a/yarn.lock
+++ b/yarn.lock
@@ -360,7 +360,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.13.10", "@babel/runtime@^7.7.2":
+"@babel/runtime@^7.13.10", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
@@ -766,6 +766,14 @@
   version "3.6.14"
   resolved "https://registry.yarnpkg.com/@mantine/modals/-/modals-3.6.14.tgz#da7b249ab79a62585921379fa005296c346b7d4c"
   integrity sha512-woMEuHhB1BeTw7lSG6JcZc7Xm6dpFP1nFgvv3OvZ2jEFKIONfPydWMdWcma3xJNUtq4pDKZ77RcFCVHQrdAR6Q==
+
+"@mantine/notifications@^3.6.14":
+  version "3.6.14"
+  resolved "https://registry.yarnpkg.com/@mantine/notifications/-/notifications-3.6.14.tgz#2e556d3c69e95ce3d797ec32b4205f2909beb9c6"
+  integrity sha512-vzhU0jXKlzVaCw0SP4smdVay2qNg6BBHbQy/FIh5jkCn5nDIPGu1h5P1lkcqXJgj3f68bB6jKz4zK8tIxAs36g==
+  dependencies:
+    clsx "^1.1.1"
+    react-transition-group "^4.4.2"
 
 "@mantine/styles@3.6.14":
   version "3.6.14"
@@ -2547,6 +2555,14 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -5504,7 +5520,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -5712,6 +5728,16 @@ react-textarea-autosize@^8.3.2:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
+
+react-transition-group@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^17.0.2:
   version "17.0.2"


### PR DESCRIPTION
## Summary of Changes
1. Extended the auth routes to set the user locally on signup/login
2. Added better feedback for auth requests using mantine notifications
3. Created a simple home page with 3 buttons (really nothing special)
4. Dynamically update the nav bar for logged out vs authenticated
5. Added route for logout 

### Screenshots
**Authenticated**
![Screen Shot 2022-03-09 at 12 48 08 PM](https://user-images.githubusercontent.com/39068407/157522110-5d9b7f08-cb6a-4bde-b073-2cfe070096b6.png)

**Guest**
![Screen Shot 2022-03-09 at 12 48 38 PM](https://user-images.githubusercontent.com/39068407/157522176-81c93829-0d10-4d99-aaf9-f824a8619b68.png)

Closes #52 