### PR TITLE
#43: Write specs for userController

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,7 +1,7 @@
 on: [pull_request]
 
 jobs:
-  client:
+  server:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/client/src/components/AuthForm.tsx
+++ b/client/src/components/AuthForm.tsx
@@ -63,9 +63,9 @@ const AuthForm: React.FC<AuthFormProps> = ({ type }) => {
 
     try {
       const res = await axios.post(`/users/${type}`, { ...values });
-      const { user } = res.data;
+      const { data } = res.data;
 
-      localStorage.setItem('user', JSON.stringify(user));
+      localStorage.setItem('user', JSON.stringify(data));
       notifications.showNotification({
         title: type === 'login' ? 'Welcome back!' : "You're In!",
         color: 'green',

--- a/client/src/components/Profile.tsx
+++ b/client/src/components/Profile.tsx
@@ -29,7 +29,7 @@ const Profile: React.FC = () => {
 
   useEffect(() => {
     axios.get(`/results/user/${user.id}`).then((res) => {
-      setResults(res.data.results);
+      setResults(res.data.data);
     });
   }, []);
 

--- a/client/src/components/RaceInfo.tsx
+++ b/client/src/components/RaceInfo.tsx
@@ -32,7 +32,7 @@ const RaceInfo: React.FC = () => {
 
   useEffect(() => {
     axios.get(`/races/get/${raceId}`).then((res) => {
-      setRace(res.data.race);
+      setRace(res.data.data);
     });
   }, []);
 

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
   globals: {
     jest: true,
     beforeEach: true,
+    beforeAll: true,
     describe: true,
     it: true,
   },

--- a/server/src/@types/xss-clean.d.ts
+++ b/server/src/@types/xss-clean.d.ts
@@ -1,0 +1,4 @@
+declare module 'xss-clean' {
+    const value: Function;
+    export default value;
+}

--- a/server/src/config/environment.ts
+++ b/server/src/config/environment.ts
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 
-export type NodeEnv = 'production' | 'development';
+export type NodeEnv = 'development'| 'production' | 'test';
 
 interface RateLimitConfig {
   maxRequests: number;
@@ -72,6 +72,21 @@ const environment: { [_ in NodeEnv]: Environment } = {
       apiKey: process.env.MAILER_API_KEY!,
       username: process.env.MAILER_USERNAME!,
       resetPasswordTemplateId: 'd-803b3420888a4b16be882f3231efbc65',
+    },
+  },
+  test: {
+    baseClientUrl: '',
+    clientUrls: [],
+    rateLimits: [
+      {
+        maxRequests: Number.MAX_SAFE_INTEGER,
+        timeWindow: 1000, // 1 Second
+      },
+    ],
+    jwt: {
+      secret: process.env.JWT_SECRET!,
+      expiryTime: 60 * 60 * 24 * 365, // 1 Year
+      secure: false,
     },
   },
 };

--- a/server/src/controllers/raceController.ts
+++ b/server/src/controllers/raceController.ts
@@ -6,5 +6,5 @@ export const handleGetRace = async (req: Request, res: Response) => {
   const { raceId } = req.params;
   const race = await getRace(raceId);
 
-  res.status(StatusCodes.OK).json({ race, errors: [] });
+  res.status(StatusCodes.OK).json({ data: race, errors: [] });
 };

--- a/server/src/controllers/resultController.ts
+++ b/server/src/controllers/resultController.ts
@@ -8,7 +8,7 @@ export const handleGetResult = async (req: Request, res: Response) => {
   const { resultId } = req.params;
   const result = await getResult(resultId);
 
-  res.status(StatusCodes.OK).json({ result, errors: [] });
+  res.status(StatusCodes.OK).json({ data: result, errors: [] });
 };
 
 export const handleGetUserResults = async (req: Request, res: Response) => {
@@ -18,5 +18,5 @@ export const handleGetUserResults = async (req: Request, res: Response) => {
   const countInt = count ? parseInt(count, 10) : RESULT_PAGE_SIZE;
   const results = await getUserResults(userId, startInt, countInt);
 
-  res.status(StatusCodes.OK).json({ results, errors: [] });
+  res.status(StatusCodes.OK).json({ data: results, errors: [] });
 };

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -27,7 +27,7 @@ export const handleSignupUser = async (req: Request, res: Response) => {
   const newUser = { ...(await signupUser(inputUser)), Results: { wpm: 0, count: 0 } };
 
   createJWT(newUser.id, res);
-  res.status(StatusCodes.CREATED).json({ user: sanitizeUserOutput(newUser), errors: [] });
+  res.status(StatusCodes.CREATED).json({ data: sanitizeUserOutput(newUser), error: null });
 };
 
 export const handleLoginUser = async (req: Request, res: Response) => {
@@ -43,9 +43,7 @@ export const handleLoginUser = async (req: Request, res: Response) => {
   }
 
   createJWT(user.id, res);
-  res.status(StatusCodes.OK).json(
-    { user: sanitizeUserOutput(user), errors: [] },
-  );
+  res.status(StatusCodes.OK).json({ data: sanitizeUserOutput(user), error: null });
 };
 
 export const handleResetPasswordEmail = async (req: Request, res: Response) => {

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -179,11 +179,11 @@ export const validateResetPasswordInput = async (input: any) => {
 // Role is removed because 99.9% our users will be USER, the ADMINS know who they are
 export const sanitizeUserOutput = (user: User & { Results: { wpm: number, count: number} }) => {
   const {
-    id, email, username, createdAt, updatedAt, Results,
+    id, email, username, Results,
   } = user;
 
   return {
-    id, email, username, createdAt, updatedAt, Results,
+    id, email, username, Results,
   };
 };
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -5,15 +5,14 @@ import rateLimit from 'express-rate-limit';
 import expressWs from 'express-ws';
 import path from 'path';
 import hpp from 'hpp';
+import xss from 'xss-clean';
+
 import WsHandler from './websocketHandler';
-import environment from './config/environment';
+import environment, { NodeEnv } from './config/environment';
 import apiRoutes from './routes/apiRoutes';
 import { openLogFiles, writeLog } from './utils/log';
 import db from './prismaClient';
 import errorMiddleware from './middlewares/errorMiddleware';
-
-// Has to be done in a 'require' because there are no type declarations
-const xss = require('xss-clean');
 
 interface UserInfo {
   username: string;
@@ -75,9 +74,11 @@ const main = async () => {
 
   app.use(errorMiddleware);
 
-  app.listen(8080, () => {
-    writeLog({ event: 'server started on port 8080', user: 'server' }, 'info');
-  });
+  if (process.env.NODE_ENV as NodeEnv !== 'test') {
+    app.listen(8080, () => {
+      writeLog({ event: 'server started on port 8080', user: 'server' }, 'info');
+    });
+  }
 };
 
 main().finally(async () => { await db.$disconnect(); });

--- a/server/src/spec/controllers/userController.spec.ts
+++ b/server/src/spec/controllers/userController.spec.ts
@@ -1,0 +1,300 @@
+import { expect } from 'chai';
+import { StatusCodes } from 'http-status-codes';
+import request from 'supertest';
+import { Role } from '@prisma/client';
+import { hash, verify } from 'argon2';
+import { PrismaClientValidationError } from '@prisma/client/runtime';
+import app from '../../server';
+
+import {
+  createResetPasswordToken,
+  resetPassword,
+  sanitizeUserOutput,
+  signupUser,
+  validateSignupInput,
+  validateLoginInput,
+  validateSendResetPasswordInput,
+  validateResetPasswordInput,
+} from '../../models/user';
+import APIError from '../../errors/apiError';
+import FieldError from '../../errors/fieldError';
+import { NotFoundError } from '../../errors/notFoundError';
+import sendResetPasswordEmail from '../../utils/mailer';
+
+jest.mock('../../models/user');
+jest.mock('../../utils/mailer');
+jest.mock('argon2');
+
+const mockValidateSignupInput = validateSignupInput as jest.MockedFunction<typeof validateSignupInput>;
+const mockValidateLoginInput = validateLoginInput as jest.MockedFunction<typeof validateLoginInput>;
+const mockValidateSendResetPasswordInput = validateSendResetPasswordInput as jest.MockedFunction<typeof validateSendResetPasswordInput>;
+const mockValidateResetPasswordInput = validateResetPasswordInput as jest.MockedFunction<typeof validateResetPasswordInput>;
+const mockResetPassword = resetPassword as jest.MockedFunction<typeof resetPassword>;
+const mockSignupUser = signupUser as jest.MockedFunction<typeof signupUser>;
+const mockCreateResetPasswordToken = createResetPasswordToken as jest.MockedFunction<typeof createResetPasswordToken>;
+const mockSanitizeUserOutput = sanitizeUserOutput as jest.MockedFunction<typeof sanitizeUserOutput>;
+
+const mockSendResetPasswordEmail = sendResetPasswordEmail as jest.MockedFunction<typeof sendResetPasswordEmail>;
+
+const mockHash = hash as jest.MockedFunction<typeof hash>;
+const mockVerify = verify as jest.MockedFunction<typeof verify>;
+
+const mockUser = {
+  id: 1,
+  username: 'testuser',
+  email: 'test@test.com',
+  password: 'secret',
+  role: Role.USER,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  passwordChangedAt: new Date(),
+};
+
+const extMockUser = { ...mockUser, Results: { wpm: 0, count: 0 } };
+const mockToken = { id: 'test', userId: 1, expiresAt: new Date() };
+
+const mockResUser = {
+  id: 1,
+  username: 'testuser',
+  email: 'test@test.com',
+  Results: { wpm: 0, count: 0 },
+};
+
+describe('userController', () => {
+  beforeEach(() => {
+    // Argon Mocks
+    mockHash.mockResolvedValue('argon2hash');
+    mockVerify.mockReset();
+
+    // User Mocks
+    mockValidateSignupInput.mockReset();
+    mockValidateLoginInput.mockReset();
+    mockValidateSendResetPasswordInput.mockReset();
+    mockValidateResetPasswordInput.mockReset();
+    mockResetPassword.mockReset();
+    mockSignupUser.mockReset();
+    mockCreateResetPasswordToken.mockReset();
+    mockSanitizeUserOutput.mockReset();
+
+    // Mailer Mocks
+    mockSendResetPasswordEmail.mockReset();
+  });
+
+  describe('handleSignupUser', () => {
+    const body = {
+      email: 'test@test.com',
+      username: 'testuser',
+      password: 'abc123ABC',
+    };
+
+    it('responds with error when body is invalid', async () => {
+      const mockError = new APIError('not found', StatusCodes.NOT_FOUND);
+      const mockResError = { message: 'not found', fieldErrors: [] };
+      mockValidateSignupInput.mockRejectedValue(mockError);
+
+      const res = await request(app).post('/api/users/signup').send(body);
+
+      expect(res.status).to.equal(StatusCodes.NOT_FOUND);
+      expect(res.body).to.deep.equal({ data: null, error: mockResError });
+      expect(mockValidateSignupInput.mock.calls).to.have.lengthOf(1);
+      expect(mockSignupUser.mock.calls).to.have.lengthOf(0);
+    });
+
+    it('responds with error when signup fails', async () => {
+      const mockError = new PrismaClientValidationError();
+      const mockResError = { message: 'invalid request', fieldErrors: [] };
+      mockSignupUser.mockRejectedValue(mockError);
+
+      const res = await request(app).post('/api/users/signup').send(body);
+
+      expect(res.status).to.equal(StatusCodes.UNPROCESSABLE_ENTITY);
+      expect(res.body).to.deep.equal({ data: null, error: mockResError });
+      expect(mockValidateSignupInput.mock.calls).to.have.lengthOf(1);
+      expect(mockSignupUser.mock.calls).to.have.lengthOf(1);
+    });
+
+    it('responds with data, jwt when signup succeeds', async () => {
+      mockSignupUser.mockResolvedValue(mockUser);
+      mockSanitizeUserOutput.mockReturnValue(mockResUser);
+      const res = await request(app).post('/api/users/signup').send(body);
+
+      expect(res.status).to.equal(StatusCodes.CREATED);
+      expect(res.body).to.deep.equal({ data: mockResUser, error: null });
+      expect(res.headers['set-cookie']).to.exist;
+      expect(mockValidateSignupInput.mock.calls).to.have.lengthOf(1);
+      expect(mockSignupUser.mock.calls).to.have.lengthOf(1);
+    });
+  });
+
+  describe('handleLoginUser', () => {
+    const path = '/api/users/login';
+    const body = {
+      identifier: 'test@test.com',
+      password: 'abc123ABC',
+    };
+
+    it('responds with error when validation throws', async () => {
+      const mockError = new APIError('not found', StatusCodes.NOT_FOUND);
+      const mockResError = { message: 'not found', fieldErrors: [] };
+      mockValidateLoginInput.mockRejectedValue(mockError);
+
+      const res = await request(app).post(path).send(body);
+
+      expect(res.status).to.equal(StatusCodes.NOT_FOUND);
+      expect(res.body).to.deep.equal({ data: null, error: mockResError });
+      expect(mockValidateLoginInput.mock.calls).to.have.lengthOf(1);
+      expect(mockVerify.mock.calls).to.have.lengthOf(0);
+    });
+
+    it('responds with error when passwords do not match', async () => {
+      const passwordError = new FieldError('password', 'abc123ABC', 'does not match for user');
+      const resError = { message: 'unauthorized', fieldErrors: [passwordError] };
+
+      // Gets the user but the password is wrong
+      mockValidateLoginInput.mockResolvedValue(extMockUser);
+      mockVerify.mockResolvedValue(false);
+
+      const res = await request(app).post(path).send(body);
+
+      expect(res.status).to.equal(StatusCodes.UNAUTHORIZED);
+      expect(res.body).to.deep.equal({ data: null, error: resError });
+      expect(mockValidateLoginInput.mock.calls).to.have.lengthOf(1);
+      expect(mockVerify.mock.calls).to.have.lengthOf(1);
+    });
+
+    it('responds with user, jwt when user exists and passwords match', async () => {
+      // Gets the user and the password is right
+      mockValidateLoginInput.mockResolvedValue(extMockUser);
+      mockVerify.mockResolvedValue(true);
+      mockSanitizeUserOutput.mockReturnValue(mockResUser);
+
+      const res = await request(app).post(path).send(body);
+
+      expect(res.status).to.equal(StatusCodes.OK);
+      expect(res.body).to.deep.equal({ data: mockResUser, error: null });
+      expect(mockValidateLoginInput.mock.calls).to.have.lengthOf(1);
+      expect(mockVerify.mock.calls).to.have.lengthOf(1);
+    });
+  });
+
+  describe('handleLogoutUser', () => {
+    const path = '/api/users/logout';
+
+    it('responds with a dummy cookie', async () => {
+      const res = await request(app).get(path);
+
+      expect(res.status).to.equal(StatusCodes.OK);
+
+      const cookieFields = (res.headers['set-cookie'][0] as string).split('; ');
+      expect(cookieFields[0]).to.equal('Bearer=logged_out');
+      expect(cookieFields[1]).to.equal('Max-Age=10');
+      expect(cookieFields[4]).to.equal('HttpOnly');
+    });
+  });
+
+  describe('handleResetPasswordEmail', () => {
+    const path = '/api/users/password-reset-email';
+    const body = { identifier: 'test@teset.com' };
+
+    it('responds with error on failed validation', async () => {
+      const mockError = new NotFoundError('user');
+      const mockResError = { message: 'user not found', fieldErrors: [] };
+      mockValidateSendResetPasswordInput.mockRejectedValue(mockError);
+
+      const res = await request(app).post(path).send(body);
+
+      expect(res.status).to.equal(StatusCodes.NOT_FOUND);
+      expect(res.body).to.deep.equal({ data: null, error: mockResError });
+      expect(mockValidateSendResetPasswordInput.mock.calls).to.have.lengthOf(1);
+      expect(mockCreateResetPasswordToken.mock.calls).to.have.lengthOf(0);
+      expect(mockSendResetPasswordEmail.mock.calls).to.have.lengthOf(0);
+    });
+
+    it('responds with error on failed token creation', async () => {
+      const mockError = new PrismaClientValidationError();
+      const mockResError = { message: 'invalid request', fieldErrors: [] };
+      mockValidateSendResetPasswordInput.mockResolvedValue(extMockUser);
+      mockCreateResetPasswordToken.mockRejectedValue(mockError);
+
+      const res = await request(app).post(path).send(body);
+
+      expect(res.status).to.equal(StatusCodes.UNPROCESSABLE_ENTITY);
+      expect(res.body).to.deep.equal({ data: null, error: mockResError });
+      expect(mockValidateSendResetPasswordInput.mock.calls).to.have.lengthOf(1);
+      expect(mockCreateResetPasswordToken.mock.calls).to.have.lengthOf(1);
+      expect(mockSendResetPasswordEmail.mock.calls).to.have.lengthOf(0);
+    });
+
+    it('responds with error on failed email send', async () => {
+      const mockError = new APIError('test error', StatusCodes.INTERNAL_SERVER_ERROR);
+      const mockResError = { message: 'test error', fieldErrors: [] };
+      mockValidateSendResetPasswordInput.mockResolvedValue(extMockUser);
+      mockCreateResetPasswordToken.mockResolvedValue(mockToken);
+      mockSendResetPasswordEmail.mockRejectedValue(mockError);
+
+      const res = await request(app).post(path).send(body);
+
+      expect(res.status).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(res.body).to.deep.equal({ data: null, error: mockResError });
+      expect(mockValidateSendResetPasswordInput.mock.calls).to.have.lengthOf(1);
+      expect(mockCreateResetPasswordToken.mock.calls).to.have.lengthOf(1);
+      expect(mockSendResetPasswordEmail.mock.calls).to.have.lengthOf(1);
+    });
+
+    it('responds with 200 ok on success', async () => {
+      mockValidateSendResetPasswordInput.mockResolvedValue(extMockUser);
+      mockCreateResetPasswordToken.mockResolvedValue(mockToken);
+
+      const res = await request(app).post(path).send(body);
+
+      expect(res.status).to.equal(StatusCodes.OK);
+      expect(res.body).to.be.empty;
+      expect(mockValidateSendResetPasswordInput.mock.calls).to.have.lengthOf(1);
+      expect(mockCreateResetPasswordToken.mock.calls).to.have.lengthOf(1);
+      expect(mockSendResetPasswordEmail.mock.calls).to.have.lengthOf(1);
+    });
+  });
+
+  describe('handleResetPassword', () => {
+    const path = '/api/users/password-reset';
+    const body = { token: mockToken.id, password: 'abc123ABC2' };
+
+    it('responds with error on failed validation', async () => {
+      const mockError = new NotFoundError('user');
+      const mockResError = { message: 'user not found', fieldErrors: [] };
+      mockValidateResetPasswordInput.mockRejectedValue(mockError);
+
+      const res = await request(app).post(path).send(body);
+
+      expect(res.status).to.equal(StatusCodes.NOT_FOUND);
+      expect(res.body).to.deep.equal({ data: null, error: mockResError });
+      expect(mockValidateResetPasswordInput.mock.calls).to.have.lengthOf(1);
+      expect(mockResetPassword.mock.calls).to.have.lengthOf(0);
+    });
+
+    it('responds with error on failed db update', async () => {
+      const mockError = new PrismaClientValidationError();
+      const mockResError = { message: 'invalid request', fieldErrors: [] };
+      mockValidateResetPasswordInput.mockResolvedValue(mockToken);
+      mockResetPassword.mockRejectedValue(mockError);
+
+      const res = await request(app).post(path).send(body);
+
+      expect(res.status).to.equal(StatusCodes.UNPROCESSABLE_ENTITY);
+      expect(res.body).to.deep.equal({ data: null, error: mockResError });
+      expect(mockValidateResetPasswordInput.mock.calls).to.have.lengthOf(1);
+      expect(mockResetPassword.mock.calls).to.have.lengthOf(1);
+    });
+
+    it('responds with status ACCEPTED on success', async () => {
+      mockValidateResetPasswordInput.mockResolvedValue(mockToken);
+
+      const res = await request(app).post(path).send(body);
+
+      expect(res.status).to.equal(StatusCodes.ACCEPTED);
+      expect(res.body).to.be.empty;
+      expect(mockValidateResetPasswordInput.mock.calls).to.have.lengthOf(1);
+      expect(mockResetPassword.mock.calls).to.have.lengthOf(1);
+    });
+  });
+});

--- a/server/src/spec/models/user.spec.ts
+++ b/server/src/spec/models/user.spec.ts
@@ -218,6 +218,8 @@ describe('user', () => {
       delete expected.password;
       delete expected.role;
       delete expected.passwordChangedAt;
+      delete expected.createdAt;
+      delete expected.updatedAt;
 
       expect(sanitized).to.deep.equal(expected);
     });

--- a/server/src/utils/log.ts
+++ b/server/src/utils/log.ts
@@ -41,9 +41,12 @@ export const writeLog = (log: Log, logType: LogType) => {
   const logInfo = Object.entries(log).map(([key, value]) => `${key}: ${value}`).join(', ');
   const logString = `${timestamp} - ${logInfo}`;
 
-  if (process.env.NODE_ENV as NodeEnv === 'production') {
+  const envName = process.env.NODE_ENV as NodeEnv;
+  if (envName === 'production') {
     writeToFile(logString, logType);
-  } else {
+  } else if (envName === 'development') {
     writeToConsole(logString, logType);
   }
+
+  // Purposely let logs fall through in test mode
 };


### PR DESCRIPTION
## Small Changes 
* renamed the server github action to `server` (it was accidentally named client)
* restructured all our responses so that if there is any data it is named `data` instead of the model being accessed (user, race, result, etc...). This simplified testing for errors and gives us a consistent response format.
* change the client code appropriately to account for the changing of the response format.
* created dummy type declarations for xss-clean since they don't exist

## Major Changes
* Added specs for the users controller using supertest, which is awesome for testing http responses. Let `usersController.spec.ts` serve as a template for testing the other controllers.

Closes #43 