### PR TITLE
#102: Get user on page reload

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,15 +1,43 @@
-import React from 'react';
-
-import Router from '@components/Router';
+import React, { useEffect, useState } from 'react';
 import { ModalsProvider } from '@mantine/modals';
 import { NotificationsProvider } from '@mantine/notifications';
 
-const App: React.FC = () => (
-  <NotificationsProvider>
-    <ModalsProvider>
-      <Router />
-    </ModalsProvider>
-  </NotificationsProvider>
-);
+import Router from '@components/Router';
+import axios from '@config/axios';
+import useUser from '@hooks/useUser';
+import { LoadingOverlay } from '@mantine/core';
+
+const App: React.FC = () => {
+  const [loading, setLoading] = useState(true);
+
+  const fetchUser = async () => {
+    try {
+      const res = await axios.get('/users/me');
+      const { data: user } = res.data;
+      localStorage.setItem('user', JSON.stringify(user));
+    } catch (e) {
+      // Clear the user only if they're supposedly authenticated
+      const user = useUser();
+      if (user.id) localStorage.removeItem('user');
+    }
+
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    (async () => {
+      await fetchUser();
+    })();
+  }, []);
+
+  return (
+    <NotificationsProvider>
+      <ModalsProvider>
+        { loading ? <LoadingOverlay visible /> : <Router /> }
+
+      </ModalsProvider>
+    </NotificationsProvider>
+  );
+};
 
 export default App;

--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -2,7 +2,6 @@ import {
   Button, Card, Container, Grid, Group, Title, useMantineTheme,
 } from '@mantine/core';
 import React from 'react';
-import { Link } from 'react-router-dom';
 
 const Home: React.FC = () => {
   const { colors } = useMantineTheme();
@@ -15,7 +14,7 @@ const Home: React.FC = () => {
           <Card style={whiteBg}>
             <Group direction="column" spacing="xs">
               <Title order={4}>Race Opponents from Around the World</Title>
-              <Link to="/room"><Button>Join a Typing Race</Button></Link>
+              <Button onClick={() => { window.location.href = '/room'; }}>Join a Typing Race</Button>
             </Group>
           </Card>
         </Grid.Col>
@@ -23,7 +22,7 @@ const Home: React.FC = () => {
           <Card style={whiteBg}>
             <Group direction="column" spacing="xs">
               <Title order={5}>Improve your typing skills alone</Title>
-              <Link to="/room/solo"><Button color="cyan">Practice Typing Alone</Button></Link>
+              <Button onClick={() => { window.location.href = '/room/solo'; }} color="cyan">Practice Typing Alone</Button>
             </Group>
           </Card>
         </Grid.Col>
@@ -31,7 +30,7 @@ const Home: React.FC = () => {
           <Card style={whiteBg}>
             <Group direction="column" spacing="xs">
               <Title order={5}>Create a room and invite your friends</Title>
-              <Link to="/room/private"><Button color="cyan">Race your friends</Button></Link>
+              <Button onClick={() => { window.location.href = '/room/private'; }} color="cyan">Race your Friends</Button>
             </Group>
           </Card>
         </Grid.Col>

--- a/server/src/@types/global.d.ts
+++ b/server/src/@types/global.d.ts
@@ -1,9 +1,9 @@
-import { User } from '@prisma/client';
+import { UserWithResults } from '../utils/types';
 
 declare global {
     namespace Express {
         interface Request {
-            user?: User
+            user?: UserWithResults
         }
     }
 }

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -2,6 +2,7 @@ import argon2 from 'argon2';
 import { Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import APIError from '../errors/apiError';
+import { UnauthenticatedError } from '../errors/unauthenticatedError';
 
 import { createJWT } from '../middlewares/authMiddleware';
 import {
@@ -73,4 +74,11 @@ export const handleLogoutUser = async (_: Request, res: Response) => {
     .cookie('Bearer', 'logged_out', { maxAge: 10 * 1000, httpOnly: true, secure: false })
     .status(StatusCodes.OK)
     .end();
+};
+
+export const handleGetMe = async (req: Request, res: Response) => {
+  const { user } = req;
+  if (!user) throw new UnauthenticatedError();
+
+  res.status(StatusCodes.OK).json({ data: sanitizeUserOutput(user), error: null });
 };

--- a/server/src/routes/userRoutes.ts
+++ b/server/src/routes/userRoutes.ts
@@ -1,7 +1,10 @@
+import { Role } from '@prisma/client';
 import express from 'express';
 import {
+  handleGetMe,
   handleLoginUser, handleLogoutUser, handleResetPassword, handleResetPasswordEmail, handleSignupUser,
 } from '../controllers/userController';
+import { protectRoute } from '../middlewares/authMiddleware';
 import catchAsync from '../utils/catchAsync';
 
 const router = express.Router({ mergeParams: true });
@@ -9,8 +12,10 @@ const router = express.Router({ mergeParams: true });
 router.route('/signup').post(catchAsync(handleSignupUser));
 router.route('/login').post(catchAsync(handleLoginUser));
 router.route('/logout').get(handleLogoutUser);
-
 router.route('/password-reset-email').post(catchAsync(handleResetPasswordEmail));
 router.route('/password-reset').post(catchAsync(handleResetPassword));
+
+router.use(catchAsync(protectRoute(Role.USER)));
+router.route('/me').get(catchAsync(handleGetMe));
 
 export default router;

--- a/server/src/spec/models/user.spec.ts
+++ b/server/src/spec/models/user.spec.ts
@@ -9,7 +9,7 @@ import { ForbiddenError } from '../../errors/forbiddenError';
 
 import {
   createResetPasswordToken,
-  getUserById,
+  getUserByField,
   resetPassword,
   sanitizeUserOutput,
   signupUser,
@@ -33,6 +33,18 @@ describe('user', () => {
     updatedAt: new Date(),
     passwordChangedAt: new Date(),
     Results: [],
+  };
+
+  const mockUserWithResults = {
+    id: 1,
+    username: 'testuser',
+    email: 'test@test.com',
+    password: 'secret',
+    role: Role.USER,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    passwordChangedAt: new Date(),
+    Results: { wpm: 0, count: 0 },
   };
 
   const mockToken = {
@@ -374,21 +386,21 @@ describe('user', () => {
     });
   });
 
-  describe(getUserById, () => {
+  describe(getUserByField, () => {
     const id = 1;
 
     it('returns the user on success', async () => {
       dbMock.user.findUnique.mockResolvedValue(mockUser);
 
-      const user = await getUserById(id);
-      expect(user).to.deep.equal(mockUser);
+      const user = await getUserByField('id', id);
+      expect(user).to.deep.equal(mockUserWithResults);
     });
 
     it('returns error on failure', async () => {
       dbMock.user.findUnique.mockRejectedValue(new PrismaClientValidationError('test error'));
 
       await expectThrowsAsync(
-        () => getUserById(id),
+        () => getUserByField('id', id),
         new PrismaClientValidationError('test error'),
       );
     });

--- a/server/src/utils/types.ts
+++ b/server/src/utils/types.ts
@@ -1,9 +1,18 @@
-export interface User {
+import { User } from '@prisma/client';
+
+export interface WsUser {
     color: string;
     charsTyped: number;
     wpm: number;
     finishTime?: Date;
     finished: boolean;
+}
+
+export interface UserWithResults extends User {
+    Results: {
+        wpm: number
+        count: number
+    }
 }
 
 export interface RaceData {
@@ -15,7 +24,7 @@ export interface RaceData {
     passage?: string,
     passageId?: number,
     users: string [],
-    userInfo: {[key: string]: User; },
+    userInfo: {[key: string]: WsUser; },
     owner: string,
 }
 

--- a/server/src/websockets/websocketHandler.ts
+++ b/server/src/websockets/websocketHandler.ts
@@ -3,7 +3,7 @@ import WebSocket from 'ws';
 import { getPassage } from '../models/passage';
 import { createRace } from '../models/race';
 import { createResult } from '../models/result';
-import { getUserByUsername } from '../models/user';
+import { getUserByField } from '../models/user';
 import { MILLISECONDS_PER_MINUTE } from '../utils/constants';
 import { getUtcTime } from '../utils/helpers';
 import {
@@ -166,7 +166,7 @@ class WsHandler {
     if (raceInfo.passageId) {
       createRace(raceInfo.passageId).then((dbRace) => {
         Object.entries(raceInfo.userInfo).forEach(([username, user]) => {
-          getUserByUsername(username).then((dbUser) => {
+          getUserByField('username', username).then((dbUser) => {
             if (dbUser) {
               createResult(dbUser.id, dbRace.id, user.wpm, 1);
             }


### PR DESCRIPTION
## Major Changes
* Add route to get user from token
* Fix `protectRoute` to read the jwt from the cookie
* Have the client get the user on each page load

## Minor Changes
* Merged the `getUserBy[Email/Id/Username]` method into a `getUserByField` method which takes the field as the first param and the value as the second param

## Unrelated Changes
* Fixed #107 by making the page reload when navigating to a room

Closes #102  