### PR TITLE
#112: Generate human readable names for guests

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "react-router": "^6.2.1",
     "react-router-dom": "^6.2.1",
     "recharts": "^2.1.9",
+    "unique-names-generator": "^4.7.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/client/src/components/WaitingRoom.tsx
+++ b/client/src/components/WaitingRoom.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { v4 as uuid } from 'uuid';
 import {
   List, ListItem, Button, Text,
 } from '@mantine/core';
@@ -38,8 +37,10 @@ const Room: React.FC<RoomProps> = (
   const [countDown, setCountDown] = useState(isPublic ? 10 : 3);
   const [errorMessage, setErrorMessage] = useState('');
   const roomId = !isPublic && !isCreator ? useParams().roomId : '';
+
   const modals = useModals();
   const navigate = useNavigate();
+  const { username } = useUser();
 
   const openModal = () => {
     modals.openModal(
@@ -104,9 +105,7 @@ const Room: React.FC<RoomProps> = (
   };
 
   useEffect(() => {
-    const user = useUser();
-    const name = user?.username ?? uuid();
-    createSocket(name);
+    createSocket(username);
   }, []);
 
   useEffect(() => {
@@ -153,7 +152,7 @@ const Room: React.FC<RoomProps> = (
             <List>
               {raceInfo.users.map((user) => <ListItem key={user}>{user}</ListItem>)}
             </List>
-            {!raceInfo.isPublic && !raceInfo.isSolo && raceInfo.owner === useUser().username && <Button color="cyan" onClick={startRace}>Race your friends</Button>}
+            {!raceInfo.isPublic && !raceInfo.isSolo && raceInfo.owner === username && <Button color="cyan" onClick={startRace}>Race your friends</Button>}
           </div>
         )}
     </div>

--- a/client/src/hooks/useUser.ts
+++ b/client/src/hooks/useUser.ts
@@ -1,4 +1,6 @@
-import { v4 as uuid } from 'uuid';
+import {
+  adjectives, animals, NumberDictionary, uniqueNamesGenerator,
+} from 'unique-names-generator';
 
 const useUser = () => {
   const localStorageUser = localStorage.getItem('user');
@@ -6,7 +8,11 @@ const useUser = () => {
     return JSON.parse(localStorageUser);
   }
 
-  const user = { username: uuid() };
+  // Store temporary guest information in local storage
+  // 1400 adjectives * 350 animals * 100 numbers = 49,000,000 unique names
+  const numbers = NumberDictionary.generate({ min: 0, max: 99 });
+  const guestName = uniqueNamesGenerator({ dictionaries: [adjectives, animals, numbers] });
+  const user = { username: guestName };
   localStorage.setItem('user', JSON.stringify(user));
 
   return user;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5293,6 +5293,7 @@ mock-socket@^9.1.0, mock-socket@^9.1.2:
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/mock-socket/-/mock-socket-9.1.2.tgz#cce6cf2193aada937ba41de3288c5c1922fbd571"
   integrity sha512-XKZkCnQ9ISOlTnaPg4LYYSMj7+6i78HyadYzLA5JM4465ibLdjappZD9Csnqc3Tfzep/eEK/LCJ29BTaLHoB1A==
+
 module-alias@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
@@ -7198,6 +7199,11 @@ undefsafe@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
+
+unique-names-generator@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/unique-names-generator/-/unique-names-generator-4.7.1.tgz#966407b12ba97f618928f77322cfac8c80df5597"
+  integrity sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow==
 
 unique-string@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Major Changes
N/A

## Minor Changes
* Use [uniqueNamesGenerator](https://www.npmjs.com/package/unique-names-generator#numbers-dictionary) instead of `uuid` to generate guest usernames on the client
* Each name has the format `adjective-animal-number`
* There are 1400+ adjectives, 350+ animals, 100 numbers totalling for 45,000,000 unique names.

Closes #112 