### PR TITLE
Added redundancy for disconnecting

### DIFF
--- a/client/src/components/WaitingRoom.tsx
+++ b/client/src/components/WaitingRoom.tsx
@@ -104,6 +104,7 @@ const Room: React.FC<RoomProps> = (
   };
 
   useEffect(() => {
+    websocket?.close();
     createSocket(myUsername);
   }, []);
 

--- a/server/src/websockets/createWebsocketConnection.ts
+++ b/server/src/websockets/createWebsocketConnection.ts
@@ -9,6 +9,7 @@ import {
 
 export const sendError = (ws: WebSocket, message: string) => {
   ws.send(JSON.stringify({ type: 'error', message }));
+  ws.close();
 };
 
 export const safeCast = <T extends InMessage> (message: InMessage) => {

--- a/server/src/websockets/websocketHandler.ts
+++ b/server/src/websockets/websocketHandler.ts
@@ -177,6 +177,9 @@ class WsHandler {
         });
       });
     }
+    raceInfo.users.forEach(user => {
+      this.disconnect_user_from_room(user, raceInfo);
+    })
   }
 
   type_char(charsTyped: number, user: string, raceInfo: RaceData) {


### PR DESCRIPTION
Major changes
- When a race finishes, it will disconnect all users in the room
- When a user navigates to Waiting room, it will disconnect the WebSocket (incase it wasn't already disconnected) and then re-establish a new connection.
- When an error occurs, it sends the erorr message and disconnects the user right away.