### PR TITLE
#136: Fix path to .env file for prod

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "NODE_ENV=development ts-node-dev --no-notify --exit-child ./src/server.ts",
-    "prod": "yarn prisma:migrate:prod && tsc && NODE_ENV=production pm2 startOrRestart pm2.config.js",
+    "prod": "tsc && NODE_ENV=production pm2 startOrRestart pm2.config.js",
     "compile": "tsc",
     "lint": "eslint src --ext .js,.ts --fix",
     "prisma:generate": "prisma generate",

--- a/server/src/config/environment.ts
+++ b/server/src/config/environment.ts
@@ -28,7 +28,15 @@ interface Environment {
 }
 
 // Must load the .env file before initializing the environment
-dotenv.config({ path: `${__dirname}/../../.env.${process.env.NODE_ENV as NodeEnv}` });
+let path;
+const envName = process.env.NODE_ENV as NodeEnv;
+if (envName === 'production') {
+  path = `${__dirname}/../../../.env.production`;
+} else {
+  path = `${__dirname}/../../.env.${envName}`;
+}
+
+dotenv.config({ path });
 
 const environment: { [_ in NodeEnv]: Environment } = {
   development: {
@@ -91,4 +99,4 @@ const environment: { [_ in NodeEnv]: Environment } = {
   },
 };
 
-export default environment[process.env.NODE_ENV as NodeEnv];
+export default environment[envName];


### PR DESCRIPTION
## Summary of Changes
- Add an additional `../` to the path if node env is production
- Remove the prisma:migrate from the server prod script because it is already executed in the root prod script.

Closes #136 